### PR TITLE
Share as much code as possible between history providers

### DIFF
--- a/modules/BrowserHistory.js
+++ b/modules/BrowserHistory.js
@@ -1,65 +1,24 @@
-import React, { PropTypes } from 'react'
+import { PropTypes } from 'react'
 import createBrowserHistory from 'history/createBrowserHistory'
-import {
-  history as historyType
-} from './PropTypes'
+import createHistoryProvider from './createHistoryProvider'
 
 /**
  * Manages session history using the HTML5 history API including
  * pushState, replaceState, and the popstate event.
  */
-class BrowserHistory extends React.Component {
-  static propTypes = {
+const BrowserHistory = createHistoryProvider(
+  {
     basename: PropTypes.string,
     forceRefresh: PropTypes.bool,
     getUserConfirmation: PropTypes.func,
-    keyLength: PropTypes.number,
-    children: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.func
-    ]).isRequired
-  }
-
-  static childContextTypes = {
-    history: historyType.isRequired
-  }
-
-  getChildContext() {
-    return {
-      history: this.history
-    }
-  }
-
-  componentWillMount() {
-    const { basename, forceRefresh, getUserConfirmation, keyLength } = this.props
-
-    this.history = createBrowserHistory({
-      basename,
-      forceRefresh,
-      getUserConfirmation,
-      keyLength
-    })
-
-    // Do this here so we catch actions in cDM.
-    this.unlisten = this.history.listen(() => this.forceUpdate())
-  }
-
-  componentWillUnmount() {
-    this.unlisten()
-  }
-
-  render() {
-    const { children } = this.props
-
-    if (typeof children !== 'function')
-      return React.Children.only(children)
-
-    return children({
-      action: this.history.action,
-      location: this.history.location,
-      history: this.history
-    })
-  }
-}
+    keyLength: PropTypes.number
+  },
+  ({ basename, forceRefresh, getUserConfirmation, keyLength }) => createBrowserHistory({
+    basename,
+    forceRefresh,
+    getUserConfirmation,
+    keyLength
+  })
+)
 
 export default BrowserHistory

--- a/modules/HashHistory.js
+++ b/modules/HashHistory.js
@@ -1,66 +1,24 @@
-import React, { PropTypes } from 'react'
+import { PropTypes } from 'react'
 import createHashHistory from 'history/createHashHistory'
-import {
-  history as historyType
-} from './PropTypes'
-
+import createHistoryProvider from './createHistoryProvider'
 /**
  * Manages session history using window.location.hash.
  */
-class HashHistory extends React.Component {
-  static propTypes = {
+const HashHistory = createHistoryProvider(
+  {
     basename: PropTypes.string,
     getUserConfirmation: PropTypes.func,
     hashType: PropTypes.oneOf([
       'hashbang',
       'noslash',
       'slash'
-    ]),
-    children: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.func
-    ]).isRequired
-  }
-
-  static childContextTypes = {
-    history: historyType.isRequired
-  }
-
-  getChildContext() {
-    return {
-      history: this.history
-    }
-  }
-
-  componentWillMount() {
-    const { basename, getUserConfirmation, hashType } = this.props
-
-    this.history = createHashHistory({
-      basename,
-      getUserConfirmation,
-      hashType
-    })
-
-    // Do this here so we catch actions in cDM.
-    this.unlisten = this.history.listen(() => this.forceUpdate())
-  }
-
-  componentWillUnmount() {
-    this.unlisten()
-  }
-
-  render() {
-    const { children } = this.props
-
-    if (typeof children !== 'function')
-      return React.Children.only(children)
-
-    return children({
-      action: this.history.action,
-      location: this.history.location,
-      history: this.history
-    })
-  }
-}
+    ])
+  },
+  ({ basename, getUserConfirmation, hashType }) => createHashHistory({
+    basename,
+    getUserConfirmation,
+    hashType
+  })
+)
 
 export default HashHistory

--- a/modules/MemoryHistory.js
+++ b/modules/MemoryHistory.js
@@ -1,64 +1,23 @@
-import React, { PropTypes } from 'react'
+import { PropTypes } from 'react'
 import createMemoryHistory from 'history/createMemoryHistory'
-import {
-  history as historyType
-} from './PropTypes'
+import createHistoryProvider from './createHistoryProvider'
 
 /**
  * Manages session history using in-memory storage.
  */
-class MemoryHistory extends React.Component {
-  static propTypes = {
+const MemoryHistory = createHistoryProvider(
+  {
     getUserConfirmation: PropTypes.func,
     initialEntries: PropTypes.array,
     initialIndex: PropTypes.number,
-    keyLength: PropTypes.number,
-    children: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.func
-    ]).isRequired
-  }
-
-  static childContextTypes = {
-    history: historyType.isRequired
-  }
-
-  getChildContext() {
-    return {
-      history: this.history
-    }
-  }
-
-  componentWillMount() {
-    const { getUserConfirmation, initialEntries, initialIndex, keyLength } = this.props
-
-    this.history = createMemoryHistory({
-      getUserConfirmation,
-      initialEntries,
-      initialIndex,
-      keyLength
-    })
-
-    // Do this here so we catch actions in cDM.
-    this.unlisten = this.history.listen(() => this.forceUpdate())
-  }
-
-  componentWillUnmount() {
-    this.unlisten()
-  }
-
-  render() {
-    const { children } = this.props
-
-    if (typeof children !== 'function')
-      return React.Children.only(children)
-
-    return children({
-      action: this.history.action,
-      location: this.history.location,
-      history: this.history
-    })
-  }
-}
+    keyLength: PropTypes.number
+  },
+  ({ getUserConfirmation, initialEntries, initialIndex, keyLength }) => createMemoryHistory({
+    getUserConfirmation,
+    initialEntries,
+    initialIndex,
+    keyLength
+  })
+)
 
 export default MemoryHistory

--- a/modules/createHistoryProvider.js
+++ b/modules/createHistoryProvider.js
@@ -1,0 +1,54 @@
+import React, { PropTypes } from 'react'
+import {
+  history as historyType
+} from './PropTypes'
+
+function createHistoryProvider(propTypes, createHistory) {
+  class HistoryProvider extends React.Component {
+    static propTypes = {
+      ...propTypes,
+      children: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.func
+      ]).isRequired
+    }
+
+    static childContextTypes = {
+      history: historyType.isRequired
+    }
+
+    getChildContext() {
+      return {
+        history: this.history
+      }
+    }
+
+    componentWillMount() {
+      this.history = createHistory(this.props)
+
+      // Do this here so we catch actions in cDM.
+      this.unlisten = this.history.listen(() => this.forceUpdate())
+    }
+
+    componentWillUnmount() {
+      this.unlisten()
+    }
+
+    render() {
+      const { children } = this.props
+
+      if (typeof children !== 'function')
+        return React.Children.only(children)
+
+      return children({
+        action: this.history.action,
+        location: this.history.location,
+        history: this.history
+      })
+    }
+  }
+
+  return HistoryProvider
+}
+
+export default createHistoryProvider


### PR DESCRIPTION
I think this may be a better approach than #15.  Rather than explicitly importing all the bits that are shared, just explicitly provide all the differences to a factory function.  This leads to a really small amount of code duplication.  I think it results in very explicit, clean code.