### PR TITLE
Update to use prop-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ These components are called "action" components because they modify the URL. Whe
 For example, you could build a very simple `<Link>` component using a `<Push>`:
 
 ```js
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { Push } from 'react-history/Actions'
 
 const Link = React.createClass({

--- a/modules/Actions.js
+++ b/modules/Actions.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import {
   history as historyType
 } from './PropTypes'

--- a/modules/BrowserHistory.js
+++ b/modules/BrowserHistory.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import createBrowserHistory from 'history/createBrowserHistory'
 import {
   history as historyType

--- a/modules/HashHistory.js
+++ b/modules/HashHistory.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import createHashHistory from 'history/createHashHistory'
 import {
   history as historyType

--- a/modules/MemoryHistory.js
+++ b/modules/MemoryHistory.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import createMemoryHistory from 'history/createMemoryHistory'
 import {
   history as historyType

--- a/modules/Prompt.js
+++ b/modules/Prompt.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import {
   history as historyType
 } from './PropTypes'

--- a/modules/PropTypes.js
+++ b/modules/PropTypes.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react'
+import PropTypes from 'prop-types'
 
 export const action = PropTypes.oneOf([
   'PUSH',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "eslint modules"
   },
   "dependencies": {
-    "history": "^4.5.0"
+    "history": "^4.5.0",
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": "15.x"


### PR DESCRIPTION
Switched to use the `prop-types` module, rather than `React.PropTypes`, as required for compatibility with React 16+